### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ a `clojure.java.jdbc` datasource definition:
 
 ```clojure
 (ns db.core
-  (:require [ring-jdbc-session.core :refer [jdbc-store]]))
+  (:require [jdbc-ring-session.core :refer [jdbc-store]]))
 
 (def db
   {:subprotocol "postgresql"


### PR DESCRIPTION
ring-jdbc-session -> jdbc-ring-session
