### PR TITLE
Fixed a typo and arguments missing from an example in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ A cleaner thread is provided in the `ring-jdbc-session.cleaner` for removing exp
 
 ```clojure
 (ns db.core
-  (:require [ring-jdbc-session.cleaner :refer [start-cleaner stop-cleaner]))
+  (:require [jdbc-ring-session.cleaner :refer [start-cleaner stop-cleaner]))
 
 (start-cleaner)
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ A cleaner thread is provided in the `ring-jdbc-session.cleaner` for removing exp
 (ns db.core
   (:require [jdbc-ring-session.cleaner :refer [start-cleaner stop-cleaner]))
 
-(start-cleaner)
+(start-cleaner db)
 
-(stop-cleaner)
+(stop-cleaner session-cleaner)
 ```
 
 The `start-cleaner` function accepts an optional map with the `:interval-secs` key that defaults to 60. This is the number of seconds to sleep between runs.


### PR DESCRIPTION
I actually discovered this while using the library: the example doesn't describe that the `(start-cleaner)` function needs a db spec, so I just passed it the optional map as the sole argument, and it broke.
I figure showing it explicitly like this will help the next developer.
