### PR TITLE
Bump deps to eliminate warnings under Clojure 1.9.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
  :dependencies [[org.clojure/clojure "1.6.0"]
                 [ring/ring-core "1.3.2"]
-                [com.taoensso/nippy "2.9.0"]
+                [com.taoensso/nippy "2.13.0"]
                 [commons-codec/commons-codec "1.10"]
                 [org.clojure/java.jdbc "0.4.2"]]
 

--- a/test/jdbc_ring_session/core_test.clj
+++ b/test/jdbc_ring_session/core_test.clj
@@ -16,16 +16,17 @@
       (jdbc/db-do-commands
        t-conn
        (jdbc/drop-table-ddl :session_store))
-      (jdbc/db-do-commands
-       t-conn
-       (jdbc/create-table-ddl
+      (catch org.h2.jdbc.JdbcBatchUpdateException e
+        (when-not (re-find #"(?i)table.+not found" (.getMessage e))
+          (throw (ex-info "Could not reset session store table in test database" {} e)))))
+    (jdbc/db-do-commands
+      t-conn
+      (jdbc/create-table-ddl
         :session_store
         [:session_id "VARCHAR(36) NOT NULL PRIMARY KEY"]
         [:idle_timeout :bigint]
         [:absolute_timeout :bigint]
-        [:value "bytea"]))
-      (catch Exception e
-        (.getMessage (.getNextException e))))))
+        [:value "bytea"]))))
 
 (use-fixtures
   :once


### PR DESCRIPTION
Using this project on Clojure >= 1.9.0 yields irritating warnings due to the addition of various predicates to `clojure.core` (e.g. `pos-int?`), which have been previously defined by transitive deps of nippy. This PR bumps the nippy rev, and as a bonus, tweaks tests such that they can be run and succeed when there isn't a test database created already.