### PR TITLE
ensure connection used for database detection is closed

### DIFF
--- a/src/jdbc_ring_session/core.clj
+++ b/src/jdbc_ring_session/core.clj
@@ -46,13 +46,14 @@
    :h2 deserialize-h2})
 
 (defn detect-db [db]
-  (let [db-name (.. (jdbc/get-connection db) getMetaData getDatabaseProductName toLowerCase)]
+  (let [db-name (with-open [conn (jdbc/get-connection db)]
+                  (.. conn getMetaData getDatabaseProductName toLowerCase))]
     (cond
-     (.contains db-name "oracle") :oracle
-     (.contains db-name "postgres") :postgres
-     (.contains db-name "mysql") :mysql
-     (.contains db-name "h2") :h2
-     :else (throw (Exception. (str "unrecognized DB: " db-name))))))
+      (.contains db-name "oracle") :oracle
+      (.contains db-name "postgres") :postgres
+      (.contains db-name "mysql") :mysql
+      (.contains db-name "h2") :h2
+      :else (throw (Exception. (str "unrecognized DB: " db-name))))))
 
 (defn read-session-value [datasource table deserialize key]
   (jdbc/with-db-transaction [conn datasource]


### PR DESCRIPTION
This isn't a problem in typical usage, but can quickly exhaust a shared connection pool if one is doing automated integration tests where a ring app including the jdbc session middleware is being brought up and down repeatedly.

FWIW, an artifact including this change is available @ `[org.clojars.cemerick/jdbc-ring-session "0.9-close-connection"]`.