### PR TITLE
Replace clojure.java.jdbc with next.jdbc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,22 @@ A Clojure library for JDBC backed Ring sessions.
 ## Usage
 
 Use the `jdbc-ring-session.core/jdbc-store` function to create a new store. The function accepts
-a `clojure.java.jdbc` datasource definition:
+a `next.jdbc` datasource definition:
 
 ```clojure
 (ns db.core
   (:require [jdbc-ring-session.core :refer [jdbc-store]]))
 
 (def db
-  {:subprotocol "postgresql"
-   :subname "session"
+  {:dbtype "postgresql"
+   :dbname "session"
    :user "admin"
    :password "admin"})
 
 (def store (jdbc-store db))
 ```
+
+The function also accepts an existing datasource, e.g. the connection pool of your application.
 
 ### database configuration
 

--- a/project.clj
+++ b/project.clj
@@ -5,9 +5,9 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
  :dependencies [[org.clojure/clojure "1.10.1"]
                 [ring/ring-core "1.8.2"]
-                [com.taoensso/nippy "3.0.0"]
+                [com.taoensso/nippy "3.1.1"]
                 [commons-codec/commons-codec "1.15"]
-                [org.clojure/java.jdbc "0.7.11"]]
+                [com.github.seancorfield/next.jdbc "1.2.724"]]
 
   :profiles
   {:dev {:dependencies [[com.h2database/h2 "1.4.200"]]}})

--- a/src/jdbc_ring_session/cleaner.clj
+++ b/src/jdbc_ring_session/cleaner.clj
@@ -7,7 +7,7 @@
   [conn {:keys [table]
          :or   {table :session_store}}]
   (let [t (quot (System/currentTimeMillis) 1000)]
-    (jdbc.sql/delete! conn (name table) ["idle_timeout < ? or absolute_timeout < ?" t t])))
+    (jdbc.sql/delete! conn table ["idle_timeout < ? or absolute_timeout < ?" t t])))
 
 (defprotocol Stoppable
   "Something that can be stopped"

--- a/src/jdbc_ring_session/cleaner.clj
+++ b/src/jdbc_ring_session/cleaner.clj
@@ -1,5 +1,5 @@
 (ns jdbc-ring-session.cleaner
-  (:require [next.jdbc :as jdbc])
+  (:require [next.jdbc.sql :as jdbc.sql])
   (:import [java.util.concurrent Executors TimeUnit ScheduledExecutorService]))
 
 (defn remove-sessions
@@ -7,7 +7,7 @@
   [conn {:keys [table]
          :or   {table :session_store}}]
   (let [t (quot (System/currentTimeMillis) 1000)]
-    (jdbc/execute! conn  [(str "delete from " (name table) " where idle_timeout < ? or absolute_timeout < ?") t t])))
+    (jdbc.sql/delete! conn (name table) ["idle_timeout < ? or absolute_timeout < ?" t t])))
 
 (defprotocol Stoppable
   "Something that can be stopped"

--- a/src/jdbc_ring_session/cleaner.clj
+++ b/src/jdbc_ring_session/cleaner.clj
@@ -1,5 +1,5 @@
 (ns jdbc-ring-session.cleaner
-  (:require [clojure.java.jdbc :as jdbc])
+  (:require [next.jdbc :as jdbc])
   (:import [java.util.concurrent Executors TimeUnit ScheduledExecutorService]))
 
 (defn remove-sessions
@@ -7,7 +7,7 @@
   [conn {:keys [table]
          :or   {table :session_store}}]
   (let [t (quot (System/currentTimeMillis) 1000)]
-    (jdbc/delete! conn table ["idle_timeout < ? or absolute_timeout < ?" t t])))
+    (jdbc/execute! conn  [(str "delete from " (name table) " where idle_timeout < ? or absolute_timeout < ?") t t])))
 
 (defprotocol Stoppable
   "Something that can be stopped"

--- a/src/jdbc_ring_session/core.clj
+++ b/src/jdbc_ring_session/core.clj
@@ -69,7 +69,8 @@
 (defn read-session-value [datasource table deserialize key]
   (jdbc/with-transaction [tx datasource]
     (-> (jdbc/execute-one! tx [(str "select value from " (name table) " where session_id = ?") key])
-        :SESSION_STORE/VALUE
+        (vals)
+        (first)
         deserialize)))
 
 (defn update-session-value! [tx table serialize key value]

--- a/test/jdbc_ring_session/cleaner_test.clj
+++ b/test/jdbc_ring_session/cleaner_test.clj
@@ -1,6 +1,7 @@
-(ns jdbc-ring-session.core-test
+(ns jdbc-ring-session.cleaner-test
   (:require [clojure.test :refer :all]
             [next.jdbc :as jdbc]
+            [jdbc-ring-session.core :refer :all]
             [jdbc-ring-session.cleaner :refer :all]))
 
 (def db {:dbtype "h2" :dbname "example"})
@@ -19,8 +20,7 @@ CREATE TABLE session_store (
 
 (use-fixtures
   :once
-  (fn [f]
-    (create-test-table db) (f)))
+  (fn [f] (create-test-table db) (f)))
 
 (deftest a-test
 

--- a/test/jdbc_ring_session/cleaner_test.clj
+++ b/test/jdbc_ring_session/cleaner_test.clj
@@ -1,0 +1,39 @@
+(ns jdbc-ring-session.core-test
+  (:require [clojure.test :refer :all]
+            [next.jdbc :as jdbc]
+            [jdbc-ring-session.cleaner :refer :all]))
+
+(def db {:dbtype "h2" :dbname "example"})
+
+(defn create-test-table [db]
+  (jdbc/with-transaction [tx db]
+    (jdbc/execute! tx ["drop table if exists session_store"])
+    (jdbc/execute! tx  ["
+CREATE TABLE session_store (
+  session_id VARCHAR(36) NOT NULL,
+  idle_timeout BIGINT DEFAULT NULL,
+  absolute_timeout BIGINT DEFAULT NULL,
+  value BINARY(10000),
+  PRIMARY KEY (session_id)
+ )"])))
+
+(use-fixtures
+  :once
+  (fn [f]
+    (create-test-table db) (f)))
+
+(deftest a-test
+
+  (let [conn (jdbc/get-datasource db)
+        store (jdbc-store conn)
+        ten-seconds-ago (- (quot (System/currentTimeMillis) 1000) 10)
+        data {:foo "bar"
+              :bar [1 2 3]
+              :ring.middleware.session-timeout/idle-timeout ten-seconds-ago
+              :ring.middleware.session-timeout/absolute-timeout ten-seconds-ago}
+        k    (.write-session store nil data)]
+
+    (testing "Delete expired sessions"
+      (is (= data (.read-session store k)))
+      (remove-sessions conn {})
+      (is (= nil (.read-session store k))))))

--- a/test/jdbc_ring_session/core_test.clj
+++ b/test/jdbc_ring_session/core_test.clj
@@ -26,8 +26,7 @@ CREATE TABLE session_store (
 
 (use-fixtures
   :once
-  (fn [f]
-    (create-test-table db) (f)))
+  (fn [f] (create-test-table db) (f)))
 
 (deftest a-test
   (testing "test session write/read"

--- a/test/jdbc_ring_session/core_test.clj
+++ b/test/jdbc_ring_session/core_test.clj
@@ -1,42 +1,43 @@
 (ns jdbc-ring-session.core-test
   (:require [clojure.test :refer :all]
-            [clojure.java.jdbc :as jdbc]
+            [next.jdbc :as jdbc]
             [jdbc-ring-session.core :refer :all]))
 
-(def db
+#_(def db
   {:classname   "org.h2.Driver"
    :subprotocol "h2"
    :subname     "./test/session.db"
    :naming         {:keys   clojure.string/lower-case
                     :fields clojure.string/upper-case}})
 
+(def db {:dbtype "h2" :dbname "example"})
+
 (defn create-test-table [db]
-  (jdbc/with-db-transaction [t-conn db]
+  (jdbc/with-transaction [tx db]
     (try
-      (jdbc/db-do-commands
-       t-conn
-       (jdbc/drop-table-ddl :session_store))
-      (catch org.h2.jdbc.JdbcBatchUpdateException e
+      (jdbc/execute! tx ["drop table session_store"])
+      (catch org.h2.jdbc.JdbcSQLSyntaxErrorException e
         (when-not (re-find #"(?i)table.+not found" (.getMessage e))
           (throw (ex-info "Could not reset session store table in test database" {} e)))))
-    (jdbc/db-do-commands
-      t-conn
-      (jdbc/create-table-ddl
-        :session_store
-        [[:session_id "VARCHAR(36) NOT NULL PRIMARY KEY"]
-         [:idle_timeout :bigint]
-         [:absolute_timeout :bigint]
-         [:value "bytea"]]))))
+    (jdbc/execute! tx  ["
+CREATE TABLE session_store (
+  session_id VARCHAR(36) NOT NULL,
+  idle_timeout BIGINT DEFAULT NULL,
+  absolute_timeout BIGINT DEFAULT NULL,
+  value BINARY(10000),
+  PRIMARY KEY (session_id)
+ )"]))
 
-(use-fixtures
-  :once
-  (fn [f] (create-test-table db) (f)))
+  (use-fixtures
+    :once
+    (fn [f] (create-test-table db) (f))))
 
 (deftest a-test
   (testing "test session write/read"
-    (let [store (jdbc-store db)
+    (let [store (jdbc-store (jdbc/get-datasource db))
           data {:foo "bar" :bar [1 2 3]}
           k    (.write-session store nil data)]
+
       (is (= data (.read-session store k)))
 
       (testing "same session-id is reused after it has expired (deleted)"


### PR DESCRIPTION
This PR relates to issue #14 and replaces clojure.java.jdbc with its successor next.jdbc

The library was replaced, the queries adjusted to fit the new API. 
Also, I changed transaction handling, as next.jdbc will override nested transactions and discourages from using them.

On the ticket I commented about compatibility issues with the "old" clojure.java.jdbc db-spec. After looking into it, it turns out that it should only affect datasources with the old "subprotocol" and "subname" parameters, which was already marked as "legacy" within clojure.java.jdbc. As "subname" can be a string which is vendor-specific, mapping these to the new format is error-prone.

Tested with a local application using PostgreSQL.