### PR TITLE
Run delete-session in transaction

### DIFF
--- a/src/jdbc_ring_session/core.clj
+++ b/src/jdbc_ring_session/core.clj
@@ -114,7 +114,8 @@
         (insert-session-value! tx table serialize value))))
   (delete-session
     [_ key]
-    (jdbc.sql/delete! datasource table {:session_id key})
+    (next.jdbc/with-transaction [tx datasource]
+      (jdbc.sql/delete! tx table {:session_id key}))
     nil))
 
 (ns-unmap *ns* '->JdbcStore)

--- a/test/jdbc_ring_session/core_test.clj
+++ b/test/jdbc_ring_session/core_test.clj
@@ -40,3 +40,16 @@ CREATE TABLE session_store (
         (.delete-session store k)
         (.write-session store k data)
         (is (= data (.read-session store k)))))))
+
+(deftest test-delete-session-transaction
+  (let [store (-> db
+                  ;; disable auto-commit
+                  (assoc-in [:options :auto-commit] false)
+                  (jdbc-store))
+        data  {:foo "bar" :bar [1 2 3]}
+        k     (.write-session store nil data)]
+
+    (testing "Delete should be run in transaction because the connection can have disabled auto-commit"
+      (is (= data (.read-session store k)))
+      (is (nil? (.delete-session store k)))
+      (is (nil? (.read-session store k))))))


### PR DESCRIPTION
This PR adds a transaction to the `delete-session` function. 

When the connection is not marked as `auto-commit`, the implicit transaction is always rolled back and `delete-session` has no effect.