### PR TITLE
Add mariadb as mysql

### DIFF
--- a/src/jdbc_ring_session/core.clj
+++ b/src/jdbc_ring_session/core.clj
@@ -71,6 +71,7 @@
       (.contains db-name "oracle") :oracle
       (.contains db-name "postgres") :postgres
       (.contains db-name "mysql") :mysql
+      (.contains db-name "mariadb") :mysql
       (.contains db-name "h2") :h2
       (.contains db-name "sql server") :sqlserver
       (.contains db-name "sqlite") :sqlite


### PR DESCRIPTION
jdbc returns mariadb as type so I want this lib to support it as mysql format.